### PR TITLE
Use service name in portal DNS

### DIFF
--- a/portal.tf
+++ b/portal.tf
@@ -11,7 +11,7 @@ module "openvpn-portal" {
   load_balancer_subnets                     = var.lb_subnet_ids
   asg_subnets                               = var.backend_subnet_ids
   zone_id                                   = data.aws_route53_zone.current.zone_id
-  dns_names                                 = ["openvpn-portal"]
+  dns_names                                 = ["${var.service_name}-portal"]
   internet_gateway_id                       = data.aws_internet_gateway.current.id
   ssh_key_name                              = local.key_pair_name
   container_port                            = 8080


### PR DESCRIPTION
The portal hostname was hardcoded to openvpn-portal.
The module assumes the OpenVPN server will have a name "var.service_name", where "service_name" is "openvpn" by default.
To make naming consistent ${var.service_name}.domain.com is the OpenVPN server and ${var.service_name}-portal.domain.com is the portal.
