### PR TITLE
use service name in EFS

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -1,8 +1,8 @@
 resource "aws_efs_file_system" "openvpn-config" {
-  creation_token = "openvpn-config"
+  creation_token = "${var.service_name}-config"
   tags = merge(
     {
-      Name = "openvpn-config"
+      Name = "${var.service_name}-config"
     },
     local.tags
   )


### PR DESCRIPTION
To support multiple VPN installations, include service name in EFS creating token.
Otherwise, error happens:
```
{
│   RespMetadata: {
│     StatusCode: 409,
│     RequestID: "8c1ac0bd-77dc-4dc5-90d1-7a733e786968"
│   },
│   ErrorCode: "FileSystemAlreadyExists",
│   FileSystemId: "fs-01827c9aa1adae81e",
│   Message_: "File system 'fs-01827c9aa1adae81e' already exists with creation token 'openvpn-config'"
│ }
```
