### PR TITLE
Add support for spot instances

### DIFF
--- a/portal.tf
+++ b/portal.tf
@@ -1,6 +1,6 @@
 module "openvpn-portal" {
   source  = "registry.infrahouse.com/infrahouse/ecs/aws"
-  version = "3.7.0"
+  version = "3.14.0"
   providers = {
     aws     = aws
     aws.dns = aws.dns
@@ -25,6 +25,7 @@ module "openvpn-portal" {
   task_max_count                            = 1
   asg_min_size                              = 1
   asg_max_size                              = 1
+  on_demand_base_capacity                   = var.on_demand_base_capacity
   asg_instance_type                         = var.portal_instance_type
   container_cpu                             = 400 # One vCPU is 1024
   container_memory                          = 200 # Value in MB

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,12 @@ variable "lb_subnet_ids" {
   type        = list(string)
 }
 
+variable "on_demand_base_capacity" {
+  description = "If specified, the ASG will request spot instances and this will be the minimal number of on-demand instances."
+  type        = number
+  default     = null
+}
+
 variable "portal-image" {
   description = "OpenVPN portal docker image"
   default     = "public.ecr.aws/infrahouse/openvpn-portal:latest"


### PR DESCRIPTION
Another important change is that the ASG's healthcheck is ELB type. We want to replace OpenVPN instance if it doesn't listen to the 1194 TCP port.