### PR TITLE
Use encrypted volume

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -35,8 +35,8 @@ module "userdata" {
     },
     {
       "efs" : {
-        "file_system_id" : aws_efs_file_system.openvpn-config.id
-        "dns_name" : aws_efs_file_system.openvpn-config.dns_name
+        "file_system_id" : aws_efs_file_system.openvpn-config-enc.id
+        "dns_name" : aws_efs_file_system.openvpn-config-enc.dns_name
       }
     },
     var.smtp_credentials_secret != null ? {

--- a/efs-replication.tf
+++ b/efs-replication.tf
@@ -1,7 +1,0 @@
-resource "aws_efs_replication_configuration" "openvpn-config" {
-  source_file_system_id = aws_efs_file_system.openvpn-config.id
-  destination {
-    region         = data.aws_region.current.name
-    file_system_id = aws_efs_file_system.openvpn-config-enc.id
-  }
-}

--- a/portal.tf
+++ b/portal.tf
@@ -35,7 +35,7 @@ module "openvpn-portal" {
   extra_instance_profile_permissions = var.extra_instance_profile_permissions
   task_efs_volumes = {
     data : {
-      file_system_id : aws_efs_file_system.openvpn-config.id
+      file_system_id : aws_efs_file_system.openvpn-config-enc.id
       container_path : "/etc/openvpn"
     }
   }


### PR DESCRIPTION
Replication is terminated.
The unencrypyted volume is available to ensure the VPN server is
available during instance refresh.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the configuration to use an encrypted EFS volume by replacing references to the existing file system with those of the encrypted file system.

### Why are these changes being made?

These changes enhance security by storing data on an encrypted Amazon EFS, thus ensuring data at rest is protected. The new configuration directly replaces the previous unencrypted references with the encrypted counterparts for both OpenVPN configuration and portal instances.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->