### PR TITLE
bring back lost unencrypted EFS

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -1,3 +1,25 @@
+resource "aws_efs_file_system" "openvpn-config" {
+  creation_token = "${var.service_name}-config"
+  tags = merge(
+    {
+      Name = "${var.service_name}-config"
+    },
+    local.default_module_tags
+  )
+}
+
+resource "aws_efs_mount_target" "openvpn-config" {
+  for_each       = toset(var.backend_subnet_ids)
+  file_system_id = aws_efs_file_system.openvpn-config.id
+  subnet_id      = each.key
+  security_groups = [
+    aws_security_group.efs.id
+  ]
+  lifecycle {
+    create_before_destroy = false
+  }
+}
+
 resource "aws_security_group" "efs" {
   description = "Security group for EFS volume"
   name_prefix = "openvpn-efs-"


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add resources for an unencrypted Amazon Elastic File System (EFS) including file system and mount targets for an OpenVPN configuration.

### Why are these changes being made?
The addition restores previously lost EFS resources needed for the OpenVPN configuration by defining the file system with relevant tags and creating mount targets for each backend subnet ID, ensuring that OpenVPN can utilize the necessary storage resources within specified subnets.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->