### PR TITLE
Fix infrahouse logging in the portal

### DIFF
--- a/portal/portal/__init__.py
+++ b/portal/portal/__init__.py
@@ -21,8 +21,8 @@ from flask import (
     send_from_directory,
 )
 from flask_dance.contrib.google import make_google_blueprint, google
-from infrahouse_toolkit.cli.ih_secrets.cmd_get import get_secret
-from infrahouse_toolkit.logging import setup_logging
+from infrahouse_core.aws import get_secret
+from infrahouse_core.logging import setup_logging
 from oauthlib.oauth2 import TokenExpiredError
 from werkzeug.middleware.proxy_fix import ProxyFix
 

--- a/portal/requirements.txt
+++ b/portal/requirements.txt
@@ -1,7 +1,7 @@
 asgiref ~= 3.8
 boto3 ~= 1.26
 botocore ~= 1.29
-infrahouse-toolkit
+infrahouse-core ~= 0.17
 Flask ~= 3.0
 Flask-Dance ~= 7.1
 uvicorn ~= 0.30


### PR DESCRIPTION
`setup_logging()` moved from infrahouse-toolkit to `infrahouse-core`.
Fixes
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/local/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.12/site-packages/uvicorn/_subprocess.py", line 80, in subprocess_started
    target(sockets=sockets)
  File "/usr/local/lib/python3.12/site-packages/uvicorn/supervisors/multiprocess.py", line 63, in target
    return self.real_target(sockets)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/uvicorn/server.py", line 67, in run
    return asyncio.run(self.serve(sockets=sockets))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/uvicorn/server.py", line 71, in serve
    await self._serve(sockets)
  File "/usr/local/lib/python3.12/site-packages/uvicorn/server.py", line 78, in _serve
    config.load()
  File "/usr/local/lib/python3.12/site-packages/uvicorn/config.py", line 436, in load
    self.loaded_app = import_from_string(self.app)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/uvicorn/importer.py", line 22, in import_from_string
    raise exc from None
  File "/usr/local/lib/python3.12/site-packages/uvicorn/importer.py", line 19, in import_from_string
    module = importlib.import_module(module_str)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/app/portal/__init__.py", line 25, in <module>
    from infrahouse_toolkit.logging import setup_logging
ModuleNotFoundError: No module named 'infrahouse_toolkit.logging'
```

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update dependencies and imports to use `infrahouse-core` instead of `infrahouse-toolkit` for logging and secret management in the portal.

### Why are these changes being made?

This change ensures that the portal now uses the more updated and maintained `infrahouse-core` package instead of the deprecated `infrahouse-toolkit`. This transition was necessary to align with the updated project standards and ensure compatibility with newer features and improvements.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->