### PR TITLE
feat!: revoke deactivated users across multiple Google Workspaces (9.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ module "vpn" {
     google  = google
   }
 
-  backend_subnet_ids         = module.management.subnet_private_ids
-  lb_subnet_ids              = module.management.subnet_public_ids
-  google_oauth_client_writer = tolist(data.aws_iam_roles.sso-admin.arns)[0]
-  zone_id                    = module.infrahouse_com.infrahouse_zone_id
-  google_workspace_admin_email = "admin@infrahouse.com"
+  backend_subnet_ids            = module.management.subnet_private_ids
+  lb_subnet_ids                 = module.management.subnet_public_ids
+  google_oauth_client_writer    = tolist(data.aws_iam_roles.sso-admin.arns)[0]
+  zone_id                       = module.infrahouse_com.infrahouse_zone_id
+  google_workspace_admin_emails = ["admin@infrahouse.com"] # one per Workspace tenant
 }
 ```
 
@@ -84,10 +84,10 @@ verification, and the revocation sync — see
 (source: [`docs/configuration.md`](docs/configuration.md)).
 
 In short: declare and pass a `google` provider (it is not auto-inherited through
-an explicit `providers` map), set `google_workspace_admin_email` to a real
-Workspace admin, `terraform apply`, then authorize domain-wide delegation once in
-the Workspace console (`sudo /opt/openvpn-wif/verify-wif.sh` on an instance prints
-the exact Client ID + scope to paste).
+an explicit `providers` map), set `google_workspace_admin_emails` to a real
+Workspace admin per tenant, `terraform apply`, then authorize domain-wide
+delegation once in **each** Workspace console (`sudo /opt/openvpn-wif/verify-wif.sh`
+on an instance prints the exact Client ID + scope to paste).
 
 ## Contributing
 
@@ -229,7 +229,7 @@ Apache 2.0 — see [LICENSE](LICENSE).
 | <a name="input_google_oauth_client_writer"></a> [google\_oauth\_client\_writer](#input\_google\_oauth\_client\_writer) | ARN of an IAM role that can update content of google\_oauth\_client secret | `string` | n/a | yes |
 | <a name="input_google_wif_pool_id"></a> [google\_wif\_pool\_id](#input\_google\_wif\_pool\_id) | Workload Identity Pool ID for the OpenVPN AWS federation. | `string` | `"openvpn-wif-pool"` | no |
 | <a name="input_google_wif_provider_id"></a> [google\_wif\_provider\_id](#input\_google\_wif\_provider\_id) | Workload Identity Pool *provider* ID for the AWS provider. | `string` | `"aws-openvpn"` | no |
-| <a name="input_google_workspace_admin_email"></a> [google\_workspace\_admin\_email](#input\_google\_workspace\_admin\_email) | Email of a Google Workspace admin the VPN impersonates to read who has been<br/>deactivated (the domain-wide-delegation "subject"). Must be a real, active<br/>Workspace user with permission to read the directory -- a non-existent<br/>address fails at runtime with `invalid_grant: Invalid email or User ID`. | `string` | n/a | yes |
+| <a name="input_google_workspace_admin_emails"></a> [google\_workspace\_admin\_emails](#input\_google\_workspace\_admin\_emails) | Google Workspace admin emails the VPN impersonates to read who has been<br/>deactivated (the domain-wide-delegation "subjects"). Provide ONE per Google<br/>Workspace tenant whose users you allow to connect -- e.g. separate tenants<br/>behind the same VPN each need their own admin here. Each must be a real,<br/>active admin in its own Workspace, and the directory-reader SA's client ID<br/>(output google\_directory\_reader\_client\_id) must be authorized for scope<br/>admin.directory.user.readonly in EACH of those Workspaces' Admin consoles.<br/>A non-existent address fails at runtime with<br/>`invalid_grant: Invalid email or User ID`. One tenant = a one-element list. | `list(string)` | n/a | yes |
 | <a name="input_gzip_userdata"></a> [gzip\_userdata](#input\_gzip\_userdata) | Whether to gzip compress the cloud-init userdata before base64 encoding.<br/><br/>When true, the userdata is gzip-compressed, significantly reducing its size.<br/>This is important because AWS limits EC2 userdata to 16 KB.<br/><br/>The OpenVPN module's userdata can exceed this limit when extra\_repos includes<br/>embedded GPG keys (~3-6 KB each), multiple SSH users, or extensive custom\_facts.<br/><br/>Default: true (recommended to avoid hitting the 16 KB limit) | `bool` | `true` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type for OpenVPN server instances.<br/><br/>Recommendation: c6in family (compute-optimized, network-optimized)<br/><br/>Why compute-optimized for VPN?<br/>- OpenVPN encryption/decryption is CPU-intensive<br/>- C-series instances provide better performance per dollar for VPN workloads<br/>- Higher single-thread performance benefits VPN connection handling<br/><br/>Recommended instance types:<br/>- c6in.large (DEFAULT): 2 vCPU, 4 GB RAM, 25 Gbps network - Best balance for production<br/>- c6in.xlarge: 4 vCPU, 8 GB RAM, 30 Gbps network - High user count (>100 concurrent)<br/>- c6in.2xlarge: 8 vCPU, 16 GB RAM, 40 Gbps network - Very high throughput needs<br/>- t3a.small: 2 vCPU, 2 GB RAM, 5 Gbps network - Development/testing only<br/><br/>Instance type impacts autoscaling:<br/>- var.autoscaling\_target\_network\_percentage uses the instance's baseline network bandwidth<br/>- Larger instances = higher network bandwidth threshold for autoscaling<br/>- Example: c6in.large (25 Gbps) @ 60% = scales at 15 Gbps<br/>- Example: c6in.xlarge (30 Gbps) @ 60% = scales at 18 Gbps<br/><br/>Cost comparison (us-east-1, on-demand):<br/>- c6in.large: ~$82/month (RECOMMENDED)<br/>- m6in.large: ~$102/month (general-purpose, 19% more expensive)<br/>- t3a.small: ~$15/month (testing only, limited network performance)<br/><br/>Network performance:<br/>- c6in family: 25-200 Gbps (network-optimized)<br/>- m6in family: 25-200 Gbps (network-optimized)<br/>- m7i family: Up to 12.5 Gbps (general-purpose)<br/>- t3/t3a family: Up to 5 Gbps (burstable)<br/><br/>When to use different instance families:<br/>- c6in: Best for production VPN (CPU + network optimized)<br/>- m6in/m7i: If you need more RAM for additional services<br/>- t3/t3a: Development, testing, or very low user count (<10 users)<br/><br/>Default: "c6in.large" | `string` | `"c6in.large"` | no |
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | SSH keypair name for accessing OpenVPN server instances.<br/><br/>⚠️  SECURITY WARNING:<br/>- SSH access should be limited to emergency troubleshooting only<br/>- Use AWS Systems Manager Session Manager for routine access instead<br/>- Restrict security group to allow SSH only from trusted IP ranges<br/>- Consider using short-lived SSH certificates instead of long-lived keys<br/>- Rotate SSH keys regularly<br/>- Monitor SSH access via CloudWatch and VPC Flow Logs<br/><br/>The key pair must exist in AWS before applying this module.<br/><br/>If not specified (null), the module will generate a temporary key pair.<br/>However, for production use, you should provide a managed key pair.<br/><br/>Example: "my-openvpn-emergency-key"<br/><br/>Default: null (module generates a temporary key) | `string` | `null` | no |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,20 +158,30 @@ gcloud projects create acme-openvpn
 
 Use that ID everywhere `YOUR_GCP_PROJECT` appears below.
 
-#### Pick a Workspace admin
+#### Pick a Workspace admin (one per tenant)
 
-`google_workspace_admin_email` is the Google Workspace admin the VPN impersonates
-(via domain-wide delegation) to read who has been deactivated. It must be:
+`google_workspace_admin_emails` is a **list** — the Google Workspace admin the VPN
+impersonates (via domain-wide delegation) to read who has been deactivated, **one
+per Workspace tenant** whose users you allow to connect. Each entry must be:
 
-- a **real, active user** in your Workspace — a made-up address fails at runtime
+- a **real, active user** in *its* Workspace — a made-up address fails at runtime
   with `invalid_grant: Invalid email or User ID`;
 - an **admin allowed to read the directory** — a super admin, or a custom admin
   role with the *Users → Read* privilege.
 
 A dedicated role account (e.g. `automation-admin@your-domain.com`) is often
 cleaner than a specific person, so revocation doesn't break when someone leaves.
-Confirm the account exists under
+Confirm each account exists under
 [Admin console → Directory → Users](https://admin.google.com/ac/users).
+
+> **One list, one SA, many Workspaces.** A GCP project is not a Google Workspace.
+> This module creates a **single** directory-reader service account in your one
+> GCP project; you authorize that same SA client ID via domain-wide delegation in
+> **each** Workspace's Admin console (see the DWD step below) and list one admin
+> per Workspace here. If your allowed domains are separate Workspace tenants (e.g.
+> `acme.io` and `acme.dev`), you need an entry for each — otherwise deactivated
+> users in the un-listed tenant keep working VPN certs. One tenant = a one-element
+> list.
 
 #### Declare the provider
 
@@ -192,7 +202,8 @@ module "openvpn" {
     google  = google   # <-- required
   }
   # ...
-  google_workspace_admin_email = "admin@example.com"  # a REAL, active Workspace admin
+  # One REAL, active admin per Workspace tenant:
+  google_workspace_admin_emails = ["admin@example.com", "admin@example.dev"]
 }
 ```
 
@@ -302,7 +313,7 @@ Inputs:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `google_workspace_admin_email` | *required* | Email of a **real** Workspace admin the VPN impersonates to read the directory. |
+| `google_workspace_admin_emails` | *required* | List of **real** Workspace admins the VPN impersonates to read the directory — one per Workspace tenant. |
 | `google_wif_pool_id` | `openvpn-wif-pool` | Workload identity pool ID. |
 | `google_wif_provider_id` | `aws-openvpn` | Workload identity pool *provider* ID. |
 | `google_directory_reader_sa_id` | `openvpn-dir-reader` | Account ID of the keyless directory-reader service account. |
@@ -318,8 +329,11 @@ Outputs:
 #### Manual, once: authorize domain-wide delegation
 
 This is the **only** part Terraform cannot do — no resource exists in
-`hashicorp/google` for it. It is a one-time action per service account and
-requires a Workspace **super admin**.
+`hashicorp/google` for it. It requires a Workspace **super admin**, and you do it
+**once in every Workspace tenant** you listed in `google_workspace_admin_emails`
+— pasting the **same** client ID + scope into each Workspace's Admin console. A
+tenant you skip leaves its deactivated users un-revoked; `verify-wif.sh` Tier 4
+checks every subject and stays red until they are all authorized.
 
 Get the exact values by running the verification script on any OpenVPN
 instance — it reads them from `wif.env`, so no `gcloud` or `terraform output`
@@ -334,16 +348,20 @@ on (once it is authorized the block is no longer shown):
 
 ```text
 === Tier 4: domain-wide delegation -> Directory API ===
-FAIL Tier 4: domain-wide delegation rejected (unauthorized_client: ...).
-  Subject: admin@example.com
+FAIL Tier 4 [admin@example.com]: domain-wide delegation rejected (unauthorized_client: ...).
+FAIL Tier 4: 1 of 1 Workspace(s) rejected DWD: admin@example.com.
   Domain-wide delegation setup (one-time, requires a Workspace super admin):
     1. Open https://admin.google.com/ac/owl/domainwidedelegation
     2. Click 'Add new' and enter exactly:
          Client ID:    110312795661293035653
          OAuth scopes: https://www.googleapis.com/auth/admin.directory.user.readonly
     3. Click Authorize.
-  Then re-run (authorization takes a few minutes to propagate).
+  Authorize the client id in EACH failing Workspace's Admin console, then
+  re-run (authorization takes a few minutes to propagate).
 ```
+
+With more than one tenant, Tier 4 prints one line per Workspace and stays red
+until **every** one is authorized.
 
 Follow those three steps in the Workspace Admin console. The menu path, if you
 prefer navigating, is **Security → Access and data control → API controls →
@@ -378,7 +396,7 @@ Success looks like:
 PASS Tier 1: instance ARN matches the locked role
 PASS Tier 2: federated token minted: ya29.d.c0AZ4bNp... ...
 PASS Tier 3: SA-impersonation token minted: ya29.c.c0AZ4bNp... ...
-PASS Tier 4: read suspended users via DWD: []
+PASS Tier 4 [admin@example.com]: read suspended users via DWD: []
 === All requested tiers passed ===
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,7 +87,7 @@ chain one link at a time, so the first failing tier tells you where to look.
 | Tier 2 fails | Federation rejected — usually the AWS role ARN does not match the attribute condition, or the pool/provider is not `ACTIVE`. |
 | Tier 3 fails | The `workloadIdentityUser` / `serviceAccountTokenCreator` bindings on the service account are missing. |
 | Tier 4: `unauthorized_client` | The subject is valid, but the SA's client ID is not authorized for the scope. Complete [domain-wide delegation](configuration.md#manual-once-authorize-domain-wide-delegation). Just authorized it? Wait a few minutes and re-run — propagation is not instant. |
-| Tier 4: `invalid_grant: Invalid email or User ID` | Google cannot find the subject: `google_workspace_admin_email` is not a real, active user in that Workspace. |
+| Tier 4: `invalid_grant: Invalid email or User ID` | Google cannot find the subject: an entry in `google_workspace_admin_emails` is not a real, active user in that Workspace. |
 | `google-auth is installed but too old` | The distro `python3-google-auth` (1.5.x) lacks `external_account` and `impersonated_credentials`. Install `google-auth >= 2` and `google-api-python-client`. |
 
 The script is read-only — it never installs or changes anything.

--- a/google-wif.tf
+++ b/google-wif.tf
@@ -65,12 +65,18 @@ locals {
     }
   })
 
+  # One admin subject per Workspace tenant. WIF_ADMIN_SUBJECTS (comma-joined) is
+  # authoritative for the toolkit (>= 2.62.0); WIF_ADMIN_SUBJECT stays as the
+  # first element so an older reader still works (first tenant only).
+  wif_admin_subjects = var.google_workspace_admin_emails
+
   wif_env_file = templatefile("${path.module}/templates/wif.env.tftpl", {
     credential_path   = local.wif_credential_path
     sa_email          = google_service_account.dir_reader.email
     sa_client_id      = google_service_account.dir_reader.unique_id
     expected_role_arn = local.instance_assumed_role_arn
-    admin_subject     = var.google_workspace_admin_email
+    admin_subject     = local.wif_admin_subjects[0]
+    admin_subjects    = join(",", local.wif_admin_subjects)
   })
 
   # Files the instance needs to use the federation, plus the self-verifying
@@ -171,18 +177,31 @@ resource "google_service_account_iam_member" "wif_token_creator" {
 # ---------------------------------------------------------------------------
 # Variables
 # ---------------------------------------------------------------------------
-variable "google_workspace_admin_email" {
+variable "google_workspace_admin_emails" {
   description = <<-EOT
-    Email of a Google Workspace admin the VPN impersonates to read who has been
-    deactivated (the domain-wide-delegation "subject"). Must be a real, active
-    Workspace user with permission to read the directory -- a non-existent
-    address fails at runtime with `invalid_grant: Invalid email or User ID`.
+    Google Workspace admin emails the VPN impersonates to read who has been
+    deactivated (the domain-wide-delegation "subjects"). Provide ONE per Google
+    Workspace tenant whose users you allow to connect -- e.g. separate tenants
+    behind the same VPN each need their own admin here. Each must be a real,
+    active admin in its own Workspace, and the directory-reader SA's client ID
+    (output google_directory_reader_client_id) must be authorized for scope
+    admin.directory.user.readonly in EACH of those Workspaces' Admin consoles.
+    A non-existent address fails at runtime with
+    `invalid_grant: Invalid email or User ID`. One tenant = a one-element list.
   EOT
-  type        = string
+  type        = list(string)
 
   validation {
-    condition     = length(trimspace(var.google_workspace_admin_email)) > 0
-    error_message = "google_workspace_admin_email must not be empty."
+    condition     = length(var.google_workspace_admin_emails) > 0
+    error_message = "Provide at least one Workspace admin email."
+  }
+  validation {
+    condition     = alltrue([for e in var.google_workspace_admin_emails : length(trimspace(e)) > 0])
+    error_message = "Workspace admin emails must not be blank."
+  }
+  validation {
+    condition     = length(var.google_workspace_admin_emails) == length(distinct(var.google_workspace_admin_emails))
+    error_message = "Workspace admin emails must be unique."
   }
 }
 

--- a/scripts/verify-wif.sh
+++ b/scripts/verify-wif.sh
@@ -38,11 +38,15 @@
 #                                   (terraform output google_directory_reader_client_id).
 #   WIF_EXPECTED_ROLE_ARN          Normalized assumed-role ARN the provider is locked to.
 #                                   If set, Tier 1 asserts the instance matches it.
-#   WIF_ADMIN_SUBJECT              Workspace admin the SA impersonates. If set, runs Tier 4.
+#   WIF_ADMIN_SUBJECTS            Comma-separated Workspace admins the SA
+#                                   impersonates, one per Workspace tenant. If set,
+#                                   Tier 4 checks EACH and is red if any fails.
+#   WIF_ADMIN_SUBJECT             Deprecated single-tenant spelling, used only when
+#                                   WIF_ADMIN_SUBJECTS is unset.
 #   WIF_DIRECTORY_SCOPE            Directory scope. Default: admin.directory.user.readonly.
 #
-# Exit status: non-zero if any required tier (1-3, and 4 when WIF_ADMIN_SUBJECT
-# is set) fails.
+# Exit status: non-zero if any required tier (1-3, and 4 when an admin subject is
+# set) fails -- for Tier 4, if ANY configured Workspace fails.
 
 set -euo pipefail
 
@@ -59,7 +63,9 @@ fi
 CRED_CONFIG="${GOOGLE_APPLICATION_CREDENTIALS:-/opt/openvpn-wif/google-wif.json}"
 SA_EMAIL="${WIF_SA_EMAIL:-}"
 EXPECTED_ROLE_ARN="${WIF_EXPECTED_ROLE_ARN:-}"
-ADMIN_SUBJECT="${WIF_ADMIN_SUBJECT:-}"
+# WIF_ADMIN_SUBJECTS (comma-separated, one admin per Workspace) is authoritative;
+# fall back to the deprecated single WIF_ADMIN_SUBJECT when it is unset.
+ADMIN_SUBJECTS="${WIF_ADMIN_SUBJECTS:-${WIF_ADMIN_SUBJECT:-}}"
 DIRECTORY_SCOPE="${WIF_DIRECTORY_SCOPE:-https://www.googleapis.com/auth/admin.directory.user.readonly}"
 
 export GOOGLE_APPLICATION_CREDENTIALS="$CRED_CONFIG"
@@ -120,7 +126,7 @@ fi
 [ -n "$SA_EMAIL" ] || fail "WIF_SA_EMAIL is required for Tiers 2-4"
 [ -f "$CRED_CONFIG" ] || fail "credential config not found at $CRED_CONFIG"
 
-"$PYTHON" - "$SA_EMAIL" "$DIRECTORY_SCOPE" "$ADMIN_SUBJECT" <<'PYEOF'
+"$PYTHON" - "$SA_EMAIL" "$DIRECTORY_SCOPE" "$ADMIN_SUBJECTS" <<'PYEOF'
 """Tiers 2-4 of the WIF runtime check, using the google-auth libraries."""
 import os
 import sys
@@ -152,7 +158,9 @@ except ImportError as error:
         f"(version {version}): {error}.\n{_INSTALL_HINT}"
     )
 
-sa_email, directory_scope, admin_subject = sys.argv[1], sys.argv[2], sys.argv[3]
+sa_email, directory_scope = sys.argv[1], sys.argv[2]
+# One admin subject per Workspace tenant (comma-separated). Empty entries dropped.
+admin_subjects = [s.strip() for s in sys.argv[3].split(",") if s.strip()]
 sa_client_id = os.environ.get("WIF_SA_CLIENT_ID", "")
 request = gt.Request()
 cloud_platform = "https://www.googleapis.com/auth/cloud-platform"
@@ -187,14 +195,17 @@ sa_credentials = impersonated_credentials.Credentials(
 sa_credentials.refresh(request)
 print("PASS Tier 3: SA-impersonation token minted:", sa_credentials.token[:22], "...")
 
-# Tier 4: domain-wide delegation -> Directory API. Opt-in: needs a real admin
-# subject AND the manual DWD authorization in the Workspace Admin console.
+# Tier 4: domain-wide delegation -> Directory API, checked per Workspace tenant.
+# Opt-in: needs a real admin subject AND the manual DWD authorization in EACH
+# Workspace's Admin console. Every configured subject must pass -- one authorized
+# Workspace is not enough when users span several tenants.
 print("=== Tier 4: domain-wide delegation -> Directory API ===")
 
 # The setup block is printed only when it is actionable (skipped or rejected) --
 # not on success, where it would be pure noise.
-if not admin_subject:
-    print("SKIP Tier 4: WIF_ADMIN_SUBJECT is empty; set it to a real Workspace admin to test the call.")
+if not admin_subjects:
+    print("SKIP Tier 4: no admin subject set (WIF_ADMIN_SUBJECTS/WIF_ADMIN_SUBJECT);"
+          " set one admin per Workspace to test the call.")
     print(dwd_setup_block())
     sys.exit(0)
 
@@ -202,28 +213,36 @@ from googleapiclient.discovery import build
 
 from google.auth.exceptions import RefreshError
 
-dwd_credentials = impersonated_credentials.Credentials(
-    source_credentials=source,
-    target_principal=sa_email,
-    target_scopes=[directory_scope],
-    subject=admin_subject,
-)
-directory = build("admin", "directory_v1", credentials=dwd_credentials, cache_discovery=False)
-try:
-    response = directory.users().list(
-        customer="my_customer", query="isSuspended=true", maxResults=5
-    ).execute()
-except RefreshError as error:
-    # Rejected until the client id above is authorized for the scope AND
-    # admin_subject is a real user in that Workspace.
-    sys.exit(
-        f"FAIL Tier 4: domain-wide delegation rejected ({error.args[0]}).\n"
-        f"  Subject: {admin_subject}\n"
-        f"{dwd_setup_block()}\n"
-        f"  Then re-run (authorization takes a few minutes to propagate)."
+failures = []
+for admin_subject in admin_subjects:
+    dwd_credentials = impersonated_credentials.Credentials(
+        source_credentials=source,
+        target_principal=sa_email,
+        target_scopes=[directory_scope],
+        subject=admin_subject,
     )
-suspended = [user["primaryEmail"] for user in response.get("users", [])]
-print("PASS Tier 4: read suspended users via DWD:", suspended)
+    directory = build("admin", "directory_v1", credentials=dwd_credentials, cache_discovery=False)
+    try:
+        response = directory.users().list(
+            customer="my_customer", query="isSuspended=true", maxResults=5
+        ).execute()
+    except RefreshError as error:
+        # Rejected until the client id above is authorized for the scope in THIS
+        # subject's Workspace AND admin_subject is a real user there.
+        print(f"FAIL Tier 4 [{admin_subject}]: domain-wide delegation rejected ({error.args[0]}).")
+        failures.append(admin_subject)
+        continue
+    suspended = [user["primaryEmail"] for user in response.get("users", [])]
+    print(f"PASS Tier 4 [{admin_subject}]: read suspended users via DWD: {suspended}")
+
+if failures:
+    sys.exit(
+        f"FAIL Tier 4: {len(failures)} of {len(admin_subjects)} Workspace(s) rejected DWD: "
+        f"{', '.join(failures)}.\n"
+        f"{dwd_setup_block()}\n"
+        f"  Authorize the client id in EACH failing Workspace's Admin console, then\n"
+        f"  re-run (authorization takes a few minutes to propagate)."
+    )
 PYEOF
 
 echo "=== All requested tiers passed ==="

--- a/templates/wif.env.tftpl
+++ b/templates/wif.env.tftpl
@@ -4,4 +4,8 @@ export GOOGLE_APPLICATION_CREDENTIALS=${credential_path}
 export WIF_SA_EMAIL=${sa_email}
 export WIF_SA_CLIENT_ID=${sa_client_id}
 export WIF_EXPECTED_ROLE_ARN=${expected_role_arn}
+# WIF_ADMIN_SUBJECTS (comma-separated, one admin per Workspace tenant) is
+# authoritative. WIF_ADMIN_SUBJECT is the first element, kept for readers older
+# than infrahouse-toolkit 2.62.0 (they cover the first tenant only).
 export WIF_ADMIN_SUBJECT=${admin_subject}
+export WIF_ADMIN_SUBJECTS=${admin_subjects}

--- a/test_data/openvpn/main.tf
+++ b/test_data/openvpn/main.tf
@@ -35,7 +35,7 @@ module "openvpn" {
   key_pair_name        = aws_key_pair.black-mbp.key_name
   allowed_domains = [
     "infrahouse.com",
-    "tinyfish.io",
+    "example.com",
   ]
   routes = [
     {
@@ -45,7 +45,7 @@ module "openvpn" {
   ]
 
   # Keyless Google Workspace directory revocation (always on).
-  google_workspace_admin_email  = var.google_workspace_admin_email
+  google_workspace_admin_emails = var.google_workspace_admin_emails
   google_wif_pool_id            = "ovpn-wif-${random_string.suffix.result}"
   google_wif_provider_id        = "aws-ovpn-${random_string.suffix.result}"
   google_directory_reader_sa_id = "ovpn-dir-${random_string.suffix.result}"

--- a/test_data/openvpn/variables.tf
+++ b/test_data/openvpn/variables.tf
@@ -15,7 +15,7 @@ variable "google_project" {
   type        = string
 }
 
-variable "google_workspace_admin_email" {
-  description = "Workspace admin the VPN impersonates to read the directory (domain-wide-delegation subject)."
-  type        = string
+variable "google_workspace_admin_emails" {
+  description = "Workspace admins the VPN impersonates to read each tenant's directory (domain-wide-delegation subjects), one per Workspace."
+  type        = list(string)
 }

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -274,8 +274,8 @@ def test_module(
                 lb_subnet_ids      = {json.dumps(subnet_public_ids)}
                 backend_subnet_ids = {json.dumps(subnet_public_ids)}
 
-                google_project               = "{google_project}"
-                google_workspace_admin_email = "{admin_email}"
+                google_project                = "{google_project}"
+                google_workspace_admin_emails = ["{admin_email}"]
                 """))
         if test_role_arn:
             fp.write(f'\nrole_arn = "{test_role_arn}"\n')

--- a/variables.tf
+++ b/variables.tf
@@ -719,5 +719,5 @@ variable "efs_backup_retention_days" {
   }
 }
 
-# The google_* variables (google_workspace_admin_email, google_wif_pool_id, ...)
+# The google_* variables (google_workspace_admin_emails, google_wif_pool_id, ...)
 # live in google-wif.tf, next to the resources they drive.


### PR DESCRIPTION
## Why

`allowed_domains` already lets VPN users from multiple Google domains log in
(portal OAuth), but directory **revocation** bound to a single
`google_workspace_admin_email` read only one Workspace (`customer='my_customer'`).
When the allowed domains are **separate Google Workspace tenants** (distinct
Workspaces, not just multiple domains inside one Workspace), only one tenant's
deactivated users had their certs revoked. The others kept working VPN certs,
reopening the ISO 27001 / SOC deprovisioning gap the feature exists to close.

## What changes

Impersonate **one DWD-authorized admin per Workspace** and union the active-user
sets. A **GCP project is not a Workspace**: one directory-reader service account in
one GCP project still serves every Workspace — only the impersonated *subject*
multiplies, and each Workspace's admin console authorizes the **same** SA client ID.

- **Breaking:** `google_workspace_admin_email` (string) → `google_workspace_admin_emails`
  (`list(string)`), validated non-empty + unique. One tenant = a one-element list.
- `wif.env` emits `WIF_ADMIN_SUBJECTS` (comma-joined, authoritative) and keeps
  `WIF_ADMIN_SUBJECT` (first element) so a pre-2.62.0 toolkit degrades to
  first-tenant-only rather than breaking.
- `verify-wif.sh` Tier 4 checks **every** subject and is red if any Workspace's
  domain-wide delegation is unauthorized.
- Docs: DWD is now a per-Workspace step; the Tier 4 example output is per-subject.

## Pairs with

**infrahouse-toolkit 2.62.0** (already released) — `ih-openvpn sync-google-users`
loops over `WIF_ADMIN_SUBJECTS` and unions **all-or-nothing** (a failed Workspace
query aborts the run; it never revokes from a partial union, which would
mis-revoke the failed tenant's active users). puppet-code needs a one-line wrapper
precheck (separate PR) to accept the plural env var; not required for this to land
safely because the module still emits `WIF_ADMIN_SUBJECT`.

## Verification

- `terraform fmt`, `make docs`, `make lint` clean; pre-commit hooks pass.
- `bash -n` + `shellcheck` clean on `verify-wif.sh`; embedded Tier-2/3/4 Python compiles.
- Integration test threads a one-element list (CI has a single Workspace); the
  multi-tenant union path is covered by the toolkit's unit tests.

## Release

**9.0.0** — `google_workspace_admin_email` is removed. `make release-major` bumps
`8.0.0 → 9.0.0` across `.bumpversion.cfg`, `locals.tf`, and the registered docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)