### PR TITLE
chore(deps): upgrade dependencies from the Renovate dashboard

### DIFF
--- a/.github/workflows/portal-CD.yaml
+++ b/.github/workflows/portal-CD.yaml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.ROLE_ARN }}
           role-session-name: github-actions

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,7 +15,7 @@ jobs:
   trivy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: config

--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ Apache 2.0 — see [LICENSE](LICENSE).
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ca_passkey"></a> [ca\_passkey](#module\_ca\_passkey) | registry.infrahouse.com/infrahouse/secret/aws | 1.1.1 |
-| <a name="module_flask_secret_key"></a> [flask\_secret\_key](#module\_flask\_secret\_key) | registry.infrahouse.com/infrahouse/secret/aws | 1.1.1 |
-| <a name="module_google_client"></a> [google\_client](#module\_google\_client) | registry.infrahouse.com/infrahouse/secret/aws | 1.1.1 |
+| <a name="module_ca_passkey"></a> [ca\_passkey](#module\_ca\_passkey) | registry.infrahouse.com/infrahouse/secret/aws | 1.3.0 |
+| <a name="module_flask_secret_key"></a> [flask\_secret\_key](#module\_flask\_secret\_key) | registry.infrahouse.com/infrahouse/secret/aws | 1.3.0 |
+| <a name="module_google_client"></a> [google\_client](#module\_google\_client) | registry.infrahouse.com/infrahouse/secret/aws | 1.3.0 |
 | <a name="module_instance_profile"></a> [instance\_profile](#module\_instance\_profile) | registry.infrahouse.com/infrahouse/instance-profile/aws | 1.9.0 |
-| <a name="module_openvpn-portal"></a> [openvpn-portal](#module\_openvpn-portal) | registry.infrahouse.com/infrahouse/ecs/aws | 8.3.1 |
+| <a name="module_openvpn-portal"></a> [openvpn-portal](#module\_openvpn-portal) | registry.infrahouse.com/infrahouse/ecs/aws | 8.4.0 |
 | <a name="module_userdata"></a> [userdata](#module\_userdata) | registry.infrahouse.com/infrahouse/cloud-init/aws | 2.4.0 |
 
 ## Resources

--- a/portal.tf
+++ b/portal.tf
@@ -1,6 +1,6 @@
 module "openvpn-portal" {
   source  = "registry.infrahouse.com/infrahouse/ecs/aws"
-  version = "8.3.1"
+  version = "8.4.0"
   providers = {
     aws     = aws
     aws.dns = aws.dns

--- a/portal/requirements.txt
+++ b/portal/requirements.txt
@@ -1,7 +1,7 @@
 asgiref ~= 3.8
 boto3 ~= 1.26
 botocore ~= 1.29
-infrahouse-core ~= 0.17
+infrahouse-core ~= 1.1
 Flask ~= 3.0
 Flask-Dance ~= 7.1
 uvicorn ~= 0.30

--- a/portal/requirements_dev.txt
+++ b/portal/requirements_dev.txt
@@ -1,14 +1,15 @@
-black ~= 26.3.1
-build ~= 0.10
+black ~= 26.5.1
+build ~= 1.5
 bump2version ~= 1.0
-isort ~= 5.12
-mdformat ~= 0.7
-mdformat-gfm ~= 0.3
-pylint ~= 2.17
+isort ~= 8.0
+mdformat ~= 1.0
+mdformat-gfm ~= 1.0
+pylint ~= 4.0
 pytest ~= 9.0
-pytest-cov ~= 4.1
+pytest-cov ~= 7.1
 pytest-timeout ~= 2.1
-sphinx ~= 6.1
+# 9.1+ requires Python >= 3.12; ~= 9.0 keeps the v9 line installable on 3.11 dev envs
+sphinx ~= 9.0
 tox ~= 4.4
-twine ~= 4.0
+twine ~= 7.0
 yamllint ~= 1.29

--- a/secrets.tf
+++ b/secrets.tf
@@ -3,8 +3,9 @@ resource "random_password" "ca_passkey" {
 }
 module "ca_passkey" {
   source             = "registry.infrahouse.com/infrahouse/secret/aws"
-  version            = "1.1.1"
+  version            = "1.3.0"
   environment        = var.environment
+  service_name       = var.service_name
   secret_description = "OpenVPN CA Key Passphrase"
   secret_name_prefix = "openvpn_ca_passphrase"
   secret_value       = random_password.ca_passkey.result
@@ -21,8 +22,9 @@ resource "random_password" "flask_secret_key" {
 }
 module "flask_secret_key" {
   source             = "registry.infrahouse.com/infrahouse/secret/aws"
-  version            = "1.1.1"
+  version            = "1.3.0"
   environment        = var.environment
+  service_name       = var.service_name
   secret_description = "Flask secret key"
   secret_name_prefix = "flask_secret_key"
   secret_value       = random_password.flask_secret_key.result
@@ -34,8 +36,9 @@ module "flask_secret_key" {
 
 module "google_client" {
   source             = "registry.infrahouse.com/infrahouse/secret/aws"
-  version            = "1.1.1"
+  version            = "1.3.0"
   environment        = var.environment
+  service_name       = var.service_name
   secret_description = "A JSON with Google OAuth Client ID"
   secret_name_prefix = "google_client"
   tags               = local.default_module_tags


### PR DESCRIPTION
## What This PR Does

Batches the approved updates from the Renovate Dependency Dashboard (#30) into one PR.

**Terraform**
- `ecs` 8.3.1 → 8.4.0 (dependency bumps only)
- `secret` 1.1.1 → 1.3.0 on all three call sites, adding `service_name` to silence the 1.3.0 deprecation
  check (changes only the `service` tag, in-place). The new cross-account CMK support is explicit opt-in and
  all three secrets are same-account, so encryption behavior is unchanged.

**GitHub Actions** (repo-owned workflows only; github-control-managed files untouched)
- `portal-CD.yaml`: `actions/checkout` v5 → v7, `aws-actions/configure-aws-credentials` v5 → v6
- `trivy.yml`: `actions/checkout` v4 → v7

**Python (portal/)**
- `infrahouse-core` ~= 0.17 → ~= 1.1 — the portal only uses `get_secret(client, name)` and
  `setup_logging(LOG, debug=…)`, both verified compatible with 1.1
- Dev tools: black 26.5.1, build 1.5, isort 8.0, mdformat 1.0, mdformat-gfm 1.0, pylint 4.0,
  pytest-cov 7.1, twine 7.0, and **sphinx ~= 9.0 instead of Renovate's ~= 9.1** (9.1 requires
  Python ≥ 3.12; dev environments run 3.11)

**Deferred on purpose**
- **google provider stays at `~> 6.0`** — the 7.x update is breaking for module callers and would force a
  major release
- **instance-profile stays at 1.9.0** — 2.0.0 grants `ec2:DescribeTags` and Inspector CIS session
  permissions by default; CIS is a separate project. (Note: ecs 8.4.0 internally uses instance-profile
  2.0.0 for the portal pod role.)

Verified locally: `terraform init -upgrade && terraform validate` in `test_data/openvpn` (google 6.50.0);
pip resolution of both portal requirement files on 3.11; checkov 0 failed, trivy clean, tflint/fmt pass.

## Type of Change

- [x] Maintenance/chore (`chore:`)

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `make lint` passes
- [ ] `make test-clean` passes (creates real AWS infrastructure)
- [x] Variable/output descriptions updated (README tables are generated by terraform-docs)
- [x] Documentation in `docs/` updated if behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)